### PR TITLE
Add dark theme toggle

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -49,6 +49,11 @@
       :confirm-text="confirmState.options.confirmText" :cancel-text="confirmState.options.cancelText"
       :loading-text="confirmState.options.loadingText" :loading="confirmState.loading" @confirm="handleConfirm"
       @cancel="handleCancel" />
+
+    <button :class="styles.themeToggle" @click="toggleTheme">
+      <span v-if="theme === 'light'">🌙</span>
+      <span v-else>☀️</span>
+    </button>
   </div>
 </template>
 
@@ -57,6 +62,8 @@ import styles from '@/styles/App.module.css';
 import ToastNotifications from '@/components/ToastNotifications.vue';
 import ConfirmModal from '@/components/ConfirmModal.vue';
 import { useConfirm } from '@/composables/useConfirm';
+import { useTheme } from '@/composables/useTheme';
 
 const { confirmState, handleConfirm, handleCancel } = useConfirm();
+const { theme, toggleTheme } = useTheme();
 </script>

--- a/frontend/src/composables/useTheme.ts
+++ b/frontend/src/composables/useTheme.ts
@@ -1,0 +1,25 @@
+import { ref, watchEffect } from 'vue';
+
+export type Theme = 'light' | 'dark';
+
+const stored = localStorage.getItem('theme') as Theme | null;
+const theme = ref<Theme>(stored || 'light');
+document.documentElement.setAttribute('data-theme', theme.value);
+
+export function useTheme() {
+  const setTheme = (newTheme: Theme) => {
+    theme.value = newTheme;
+  };
+
+  const toggleTheme = () => {
+    theme.value = theme.value === 'light' ? 'dark' : 'light';
+  };
+
+  watchEffect(() => {
+    const root = document.documentElement;
+    root.setAttribute('data-theme', theme.value);
+    localStorage.setItem('theme', theme.value);
+  });
+
+  return { theme, setTheme, toggleTheme };
+}

--- a/frontend/src/styles/App.module.css
+++ b/frontend/src/styles/App.module.css
@@ -188,3 +188,21 @@
   font-size: var(--font-size-sm);
   color: var(--text-secondary);
 }
+
+.themeToggle {
+  position: fixed;
+  bottom: var(--spacing-lg);
+  left: var(--spacing-lg);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.themeToggle:hover {
+  background: var(--bg-hover);
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -111,6 +111,21 @@
   --z-toast: 1200;
 }
 
+[data-theme='dark'] {
+  --bg-primary: #1f2937;
+  --bg-secondary: #0f172a;
+  --bg-card: #1e293b;
+  --bg-hover: #334155;
+
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5e1;
+  --text-muted: #94a3b8;
+  --text-white: #ffffff;
+
+  --border-color: #334155;
+  --border-hover: #475569;
+}
+
 
 /* Reset CSS et styles de base */
 * {
@@ -127,8 +142,8 @@ html {
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   line-height: 1.6;
-  color: #1f2937;
-  background-color: #f9fafb;
+  color: var(--text-primary);
+  background-color: var(--bg-secondary);
   min-height: 100vh;
 }
 


### PR DESCRIPTION
## Summary
- add theme toggle button
- add `useTheme` composable
- support dark theme variables
- base body colors on CSS variables

## Testing
- `npm run lint` *(fails: jiti missing due to network restrictions)*
- `pytest -q` *(fails: httpx missing due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685adddf59e08327bb578319f0827c1f