### PR TITLE
Add new antoniouve theme

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -4,6 +4,7 @@ import App from './App.vue'
 
 // Import des styles globaux
 import './styles/global.css'
+import './styles/theme-antoniouve.css'
 
 // Configuration du routeur
 const router = createRouter({
@@ -12,20 +13,20 @@ const router = createRouter({
     {
       path: '/',
       name: 'Home',
-      component: () => import('./views/Home.vue')
+      component: () => import('./views/Home.vue'),
     },
     {
       path: '/todolist/:id',
       name: 'TodoListDetail',
       component: () => import('./views/TodoListDetail.vue'),
-      props: true
+      props: true,
     },
     {
       path: '/statistics',
       name: 'Statistics',
-      component: () => import('./views/Statistics.vue')
-    }
-  ]
+      component: () => import('./views/Statistics.vue'),
+    },
+  ],
 })
 
 // Création et montage de l'application

--- a/frontend/src/styles/theme-antoniouve.css
+++ b/frontend/src/styles/theme-antoniouve.css
@@ -1,0 +1,37 @@
+/* Theme inspired by antoniouve.com */
+:root {
+  --primary-color: #7c3aed;
+  --primary-hover: #6b21a8;
+  --primary-light: #f5f3ff;
+
+  --secondary-color: #60a5fa;
+  --secondary-hover: #3b82f6;
+
+  --bg-primary: #fafafa;
+  --bg-secondary: #f1f5f9;
+  --bg-card: #ffffff;
+  --bg-hover: #e5e7eb;
+
+  --text-primary: #1f2937;
+  --text-secondary: #4b5563;
+  --text-muted: #9ca3af;
+
+  --border-color: #e5e7eb;
+  --border-hover: #d1d5db;
+  --border-focus: #7c3aed;
+
+  --font-family-main: 'Poppins', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+[data-theme='dark'] {
+  --bg-primary: #1e1b4b;
+  --bg-secondary: #0f172a;
+  --bg-card: #1e1b4b;
+  --bg-hover: #312e81;
+
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5e1;
+
+  --border-color: #312e81;
+  --border-hover: #4338ca;
+}


### PR DESCRIPTION
## Summary
- add `theme-antoniouve.css` with purple/blue palette
- import the new theme in `main.ts`

## Testing
- `npm run lint` *(fails: jiti missing)*
- `npm run format`
- `make test` *(fails: venv missing)*

------
https://chatgpt.com/codex/tasks/task_e_686106d92f98832784fcd53cd01a2f12